### PR TITLE
Update readme, remove Drive data link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ Instead, the `notebooks/prepare_cell_data.ipynb` Jupyter notebook contains instr
 for downloading the raw data, and the notebook itself will process the data set and
 write out a compressed parquet file to the `./data` directory.
 
-Alternatively, download the `cell_towers.parq.zip` file from Google drive at
-https://drive.google.com/open?id=1mOZq24EFI0eNC2xtVEFQyPxVPHLZI9QN, then unzip it as
-`cell_towers.parq` (even though it has a file extension, this will be a directory)
-and place it at `data/cell_towers.parq`. 
-
 ## Mapbox setup
 To run the dashboard, create a file name `.mapbox_token` under to root directory. This
 file should contain a valid Mapbox token, which can be obtained for free by setting up


### PR DESCRIPTION
Removed the link to Plotly's Drive folder containing the dataset as it is not accessible to the public. 